### PR TITLE
Shorter detection periods for demo purposes

### DIFF
--- a/install-k8s-master.sh
+++ b/install-k8s-master.sh
@@ -15,6 +15,10 @@ cp -f ./rootfs/lib/systemd/system/docker.service /lib/systemd/system/docker.serv
 cp -f ./rootfs/lib/systemd/system/docker.socket /lib/systemd/system/docker.socket
 cp -f ./rootfs/lib/systemd/system/k8s-master.service /lib/systemd/system/k8s-master.service
 
+echo "Copying configuration for faster timeout"
+mkdir -p /etc/kubernetes/manifests-multi/
+cp -f ./rootfs/etc/kubernetes/manifests-multi/master.json /etc/kubernetes/manifests-multi/master.json
+
 echo "Reloading the system service configuration"
 systemctl daemon-reload
 

--- a/rootfs/etc/kubernetes/manifests-multi/master.json
+++ b/rootfs/etc/kubernetes/manifests-multi/master.json
@@ -1,0 +1,45 @@
+{
+"apiVersion": "v1",
+"kind": "Pod",
+"metadata": {"name":"k8s-master"},
+"spec":{
+  "hostNetwork": true,
+  "containers":[
+    {
+      "name": "controller-manager",
+      "image": "gcr.io/google_containers/hyperkube-arm:v1.1.2",
+      "command": [
+              "/hyperkube",
+              "controller-manager",
+              "--master=127.0.0.1:8080",
+              "--v=2",
+              "--node-monitor-grace-period=10s",
+              "--pod-eviction-timeout=5s"
+        ]
+    },
+    {
+      "name": "apiserver",
+      "image": "gcr.io/google_containers/hyperkube-arm:v1.1.2",
+      "command": [
+              "/hyperkube",
+              "apiserver",
+              "--service-cluster-ip-range=10.0.0.1/24",
+              "--address=0.0.0.0",
+              "--etcd-servers=http://127.0.0.1:4001",
+              "--cluster-name=kubernetes",
+              "--v=2"
+        ]
+    },
+    {
+      "name": "scheduler",
+      "image": "gcr.io/google_containers/hyperkube-arm:v1.1.2",
+      "command": [
+              "/hyperkube",
+              "scheduler",
+              "--master=127.0.0.1:8080",
+              "--v=2"
+        ]
+    }
+  ]
+ }
+}

--- a/rootfs/lib/systemd/system/k8s-master.service
+++ b/rootfs/lib/systemd/system/k8s-master.service
@@ -18,6 +18,7 @@ ExecStart=/bin/bash -c "exec docker run \
                         -v /dev:/dev \
                         -v /var/lib/docker/:/var/lib/docker:rw \
                         -v /var/lib/kubelet/:/var/lib/kubelet:rw \
+                        -v /etc/kubernetes/manifests-multi:/etc/kubernetes/manifests-multi:rw \
 						gcr.io/google_containers/hyperkube-arm:v1.1.2 /hyperkube kubelet \
 							--v=2 \
 							--address=0.0.0.0 \


### PR DESCRIPTION
This pull request configures the controller manager for faster marking of unhealthy nodes and faster rescheduling of pods on failed nodes. This makes it easier to demo what is going on. Feel free to merge it if you like the feature.

The variables added for the controller manager are
- --node-monitor-grace-period=10s
- --pod-eviction-timeout=5s

The added file master.json is extracted from the running container, afterwards the lines above have been added. In k8s-master.service this file is mounted on the right location.

The version has been installed and tested on a local cluster.

The credit goes to Ray for describing how it is done under "Reducing Failure Detection Periods for Demonstration Purposes" on the following post
https://medium.com/google-cloud/everything-you-need-to-know-about-the-kubernetes-raspberry-pi-cluster-2a2413bfa0fa#.h0m5g7f2q
