### PR TITLE
upgrade to hyperkube-arm:v1.2.0, docker >1.8 comp

### DIFF
--- a/install-k8s-master.sh
+++ b/install-k8s-master.sh
@@ -41,7 +41,7 @@ echo "Starting the docker service"
 systemctl start docker.service
 
 echo "Pulling necessary hyperkube Docker image"
-docker pull gcr.io/google_containers/hyperkube-arm:v1.1.2
+docker pull gcr.io/google_containers/hyperkube-arm:v1.2.0
 echo "Starting the kubernetes master service"
 systemctl start k8s-master.service
 

--- a/install-k8s-worker.sh
+++ b/install-k8s-worker.sh
@@ -33,7 +33,7 @@ echo "Starting the docker service"
 systemctl start docker.service
 
 echo "Pulling necessary hyperkube Docker image"
-docker pull gcr.io/google_containers/hyperkube-arm:v1.1.2
+docker pull gcr.io/google_containers/hyperkube-arm:v1.2.0
 echo "Starting the kubernetes worker service"
 systemctl start k8s-worker.service
 

--- a/rootfs/lib/systemd/system/docker-bootstrap.service
+++ b/rootfs/lib/systemd/system/docker-bootstrap.service
@@ -5,7 +5,7 @@ After=network.target docker-bootstrap.socket
 Requires=docker-bootstrap.socket
 
 [Service]
-ExecStart=/usr/bin/docker daemon -H unix:///var/run/docker-bootstrap.sock -p /var/run/docker-bootstrap.pid --storage-driver=overlay --storage-opt dm.basesize=10G --iptables=false --ip-masq=false --bridge=none --graph=/var/lib/docker-bootstrap
+ExecStart=/usr/bin/docker daemon -H unix:///var/run/docker-bootstrap.sock -p /var/run/docker-bootstrap.pid --storage-driver=overlay --storage-opt dm.basesize=10G --iptables=false --ip-masq=false --bridge=none --graph=/var/lib/docker-bootstrap 
 ExecStartPost=/bin/bash -c "sleep 10"
 MountFlags=slave
 LimitNOFILE=1048576

--- a/rootfs/lib/systemd/system/docker-bootstrap.service
+++ b/rootfs/lib/systemd/system/docker-bootstrap.service
@@ -5,7 +5,7 @@ After=network.target docker-bootstrap.socket
 Requires=docker-bootstrap.socket
 
 [Service]
-ExecStart=/usr/bin/docker daemon -H unix:///var/run/docker-bootstrap.sock -p /var/run/docker-bootstrap.pid --storage-driver=overlay --storage-opt dm.basesize=10G --iptables=false --ip-masq=false --bridge=none --graph=/var/lib/docker-bootstrap 
+ExecStart=/usr/bin/docker daemon -H unix:///var/run/docker-bootstrap.sock -p /var/run/docker-bootstrap.pid --storage-driver=overlay --storage-opt dm.basesize=10G --iptables=false --ip-masq=false --bridge=none --graph=/var/lib/docker-bootstrap
 ExecStartPost=/bin/bash -c "sleep 10"
 MountFlags=slave
 LimitNOFILE=1048576

--- a/rootfs/lib/systemd/system/docker.service
+++ b/rootfs/lib/systemd/system/docker.service
@@ -8,7 +8,7 @@ Requires=docker.socket k8s-flannel.service
 EnvironmentFile=/etc/kubernetes/subnet.env
 ExecStartPre=-/sbin/ifconfig docker0 down
 ExecStartPre=-/sbin/brctl delbr docker0
-ExecStart=/usr/bin/docker -d -bip=${FLANNEL_SUBNET} -mtu=${FLANNEL_MTU} -H fd:// $DOCKER_OPTS
+ExecStart=/usr/bin/docker daemon -bip=${FLANNEL_SUBNET} -mtu=${FLANNEL_MTU} -H fd:// $DOCKER_OPTS
 EnvironmentFile=-/etc/default/docker
 ExecStartPost=/bin/bash -c "sleep 10"
 MountFlags=slave

--- a/rootfs/lib/systemd/system/k8s-master.service
+++ b/rootfs/lib/systemd/system/k8s-master.service
@@ -18,7 +18,7 @@ ExecStart=/bin/bash -c "exec docker run \
                         -v /dev:/dev \
                         -v /var/lib/docker/:/var/lib/docker:rw \
                         -v /var/lib/kubelet/:/var/lib/kubelet:rw \
-						gcr.io/google_containers/hyperkube-arm:v1.1.2 /hyperkube kubelet \
+						gcr.io/google_containers/hyperkube-arm:v1.2.0 /hyperkube kubelet \
 							--v=2 \
 							--address=0.0.0.0 \
 							--enable-server \
@@ -34,7 +34,7 @@ ExecStartPost=/bin/bash -c "sleep 10;/usr/bin/docker run -d \
 						--name=k8s-master-proxy \
 						--net=host \
 						--privileged \
-						gcr.io/google_containers/hyperkube-arm:v1.1.2 /hyperkube proxy \
+						gcr.io/google_containers/hyperkube-arm:v1.2.0 /hyperkube proxy \
 							--master=http://127.0.0.1:8080 \
 							--v=2"
 #ExecStop=/usr/bin/docker stop k8s-master k8s-master-proxy

--- a/rootfs/lib/systemd/system/k8s-worker.service
+++ b/rootfs/lib/systemd/system/k8s-worker.service
@@ -17,7 +17,7 @@ ExecStart=/bin/bash -c "exec docker run \
                         -v /dev:/dev \
                         -v /var/lib/docker/:/var/lib/docker:rw \
                         -v /var/lib/kubelet/:/var/lib/kubelet:rw \
-						gcr.io/google_containers/hyperkube-arm:v1.1.2 /hyperkube kubelet \
+						gcr.io/google_containers/hyperkube-arm:v1.2.0 /hyperkube kubelet \
 							--v=2 \
 							--address=0.0.0.0 \
 							--enable-server \
@@ -32,7 +32,7 @@ ExecStartPost=/bin/bash -c "sleep 10;/usr/bin/docker run -d \
 						--name=k8s-worker-proxy \
 						--net=host \
 						--privileged \
-						gcr.io/google_containers/hyperkube-arm:v1.1.2 /hyperkube proxy \
+						gcr.io/google_containers/hyperkube-arm:v1.2.0 /hyperkube proxy \
 							--master=http://${K8S_MASTER_IP}:8080 \
 							--v=2"
 #ExecStop=/usr/bin/docker stop k8s-worker k8s-worker-proxy


### PR DESCRIPTION
changes to get the scripts working with the hypriot-rpi-20160306-192317.img RaspberryPi Images and recent hypercube-arm version.

upgrade hypercube-arm version used in scripts
replace docker's deprecated '-d' with 'daemon'

thanks to @sclassen and @moschkom for the great code camp
