### PR TITLE
Updated Docker daemon options

### DIFF
--- a/rootfs/lib/systemd/system/docker.service
+++ b/rootfs/lib/systemd/system/docker.service
@@ -8,7 +8,7 @@ Requires=docker.socket k8s-flannel.service
 EnvironmentFile=/etc/kubernetes/subnet.env
 ExecStartPre=-/sbin/ifconfig docker0 down
 ExecStartPre=-/sbin/brctl delbr docker0
-ExecStart=/usr/bin/docker -d -bip=${FLANNEL_SUBNET} -mtu=${FLANNEL_MTU} -H fd:// $DOCKER_OPTS
+ExecStart=/usr/bin/docker daemon -bip=${FLANNEL_SUBNET} -mtu=${FLANNEL_MTU} -H fd:// $DOCKER_OPTS
 EnvironmentFile=-/etc/default/docker
 ExecStartPost=/bin/bash -c "sleep 10"
 MountFlags=slave


### PR DESCRIPTION
Modified systemd unit file to fix daemon (1.10.3) failure with error message 'flag provided but not defined: -d' on HypriotOS Version 0.7.0 Berry (beta).
