### PR TITLE
Upgrade to Hyperkube v1.3.3 and Docker v1.11 fixes

### DIFF
--- a/install-k8s-master.sh
+++ b/install-k8s-master.sh
@@ -41,7 +41,7 @@ echo "Starting the docker service"
 systemctl start docker.service
 
 echo "Pulling necessary hyperkube Docker image"
-docker pull gcr.io/google_containers/hyperkube-arm:v1.1.2
+docker pull gcr.io/google_containers/hyperkube-arm:v1.3.3
 echo "Starting the kubernetes master service"
 systemctl start k8s-master.service
 

--- a/install-k8s-worker.sh
+++ b/install-k8s-worker.sh
@@ -33,7 +33,7 @@ echo "Starting the docker service"
 systemctl start docker.service
 
 echo "Pulling necessary hyperkube Docker image"
-docker pull gcr.io/google_containers/hyperkube-arm:v1.1.2
+docker pull gcr.io/google_containers/hyperkube-arm:v1.3.3
 echo "Starting the kubernetes worker service"
 systemctl start k8s-worker.service
 

--- a/rootfs/lib/systemd/system/docker-bootstrap.service
+++ b/rootfs/lib/systemd/system/docker-bootstrap.service
@@ -5,7 +5,7 @@ After=network.target docker-bootstrap.socket
 Requires=docker-bootstrap.socket
 
 [Service]
-ExecStart=/usr/bin/docker daemon -H unix:///var/run/docker-bootstrap.sock -p /var/run/docker-bootstrap.pid --storage-driver=overlay --storage-opt dm.basesize=10G --iptables=false --ip-masq=false --bridge=none --graph=/var/lib/docker-bootstrap
+ExecStart=/usr/bin/docker daemon -H unix:///var/run/docker-bootstrap.sock -p /var/run/docker-bootstrap.pid --storage-driver=overlay --storage-opt dm.basesize=10G --iptables=false --ip-masq=false --bridge=none --graph=/var/lib/docker-bootstrap --exec-root=/var/lib/docker-bootstrap
 ExecStartPost=/bin/bash -c "sleep 10"
 MountFlags=slave
 LimitNOFILE=1048576

--- a/rootfs/lib/systemd/system/docker.service
+++ b/rootfs/lib/systemd/system/docker.service
@@ -8,7 +8,7 @@ Requires=docker.socket k8s-flannel.service
 EnvironmentFile=/etc/kubernetes/subnet.env
 ExecStartPre=-/sbin/ifconfig docker0 down
 ExecStartPre=-/sbin/brctl delbr docker0
-ExecStart=/usr/bin/docker -d -bip=${FLANNEL_SUBNET} -mtu=${FLANNEL_MTU} -H fd:// $DOCKER_OPTS
+ExecStart=/usr/bin/docker daemon -bip=${FLANNEL_SUBNET} -mtu=${FLANNEL_MTU} -H fd:// $DOCKER_OPTS
 EnvironmentFile=-/etc/default/docker
 ExecStartPost=/bin/bash -c "sleep 10"
 MountFlags=slave

--- a/rootfs/lib/systemd/system/k8s-etcd.service
+++ b/rootfs/lib/systemd/system/k8s-etcd.service
@@ -6,7 +6,7 @@ After=docker-bootstrap.service
 #TimeoutStartSec=120
 ExecStartPre=-/usr/bin/docker -H unix:///var/run/docker-bootstrap.sock kill k8s-etcd
 ExecStartPre=-/usr/bin/docker -H unix:///var/run/docker-bootstrap.sock rm k8s-etcd
-ExecStartPre=-/usr/bin/mkdir -p /var/lib/kubernetes/etcd
+ExecStartPre=-/bin/mkdir -p /var/lib/kubernetes/etcd
 ExecStart=/usr/bin/docker -H unix:///var/run/docker-bootstrap.sock run -d --net=host --name=k8s-etcd -v /var/lib/kubernetes/etcd:/var/etcd/data andrewpsuedonym/etcd:2.1.1 /bin/etcd --addr=127.0.0.1:4001 --bind-addr=0.0.0.0:4001 --data-dir=/var/etcd/data
 ExecStartPost=/bin/bash -c "sleep 10;/usr/bin/docker -H unix:///var/run/docker-bootstrap.sock run --net=host andrewpsuedonym/etcd:2.1.1 etcdctl set /coreos.com/network/config '{ \"Network\": \"10.0.0.0/16\" }'"
 #ExecStop=/usr/bin/docker -H unix:///var/run/docker-bootstrap.sock stop k8s-etcd

--- a/rootfs/lib/systemd/system/k8s-master.service
+++ b/rootfs/lib/systemd/system/k8s-master.service
@@ -18,7 +18,7 @@ ExecStart=/bin/bash -c "exec docker run \
                         -v /dev:/dev \
                         -v /var/lib/docker/:/var/lib/docker:rw \
                         -v /var/lib/kubelet/:/var/lib/kubelet:rw \
-						gcr.io/google_containers/hyperkube-arm:v1.1.2 /hyperkube kubelet \
+						gcr.io/google_containers/hyperkube-arm:v1.3.3 /hyperkube kubelet \
 							--v=2 \
 							--address=0.0.0.0 \
 							--enable-server \
@@ -34,7 +34,7 @@ ExecStartPost=/bin/bash -c "sleep 10;/usr/bin/docker run -d \
 						--name=k8s-master-proxy \
 						--net=host \
 						--privileged \
-						gcr.io/google_containers/hyperkube-arm:v1.1.2 /hyperkube proxy \
+						gcr.io/google_containers/hyperkube-arm:v1.3.3 /hyperkube proxy \
 							--master=http://127.0.0.1:8080 \
 							--v=2"
 #ExecStop=/usr/bin/docker stop k8s-master k8s-master-proxy

--- a/rootfs/lib/systemd/system/k8s-worker.service
+++ b/rootfs/lib/systemd/system/k8s-worker.service
@@ -17,7 +17,7 @@ ExecStart=/bin/bash -c "exec docker run \
                         -v /dev:/dev \
                         -v /var/lib/docker/:/var/lib/docker:rw \
                         -v /var/lib/kubelet/:/var/lib/kubelet:rw \
-						gcr.io/google_containers/hyperkube-arm:v1.1.2 /hyperkube kubelet \
+						gcr.io/google_containers/hyperkube-arm:v1.3.3 /hyperkube kubelet \
 							--v=2 \
 							--address=0.0.0.0 \
 							--enable-server \
@@ -32,7 +32,7 @@ ExecStartPost=/bin/bash -c "sleep 10;/usr/bin/docker run -d \
 						--name=k8s-worker-proxy \
 						--net=host \
 						--privileged \
-						gcr.io/google_containers/hyperkube-arm:v1.1.2 /hyperkube proxy \
+						gcr.io/google_containers/hyperkube-arm:v1.3.3 /hyperkube proxy \
 							--master=http://${K8S_MASTER_IP}:8080 \
 							--v=2"
 #ExecStop=/usr/bin/docker stop k8s-worker k8s-worker-proxy


### PR DESCRIPTION
- Upgrade Hyperkube to v1.3.3
- Fix invalid command `-d` for Docker > v1.8
- Fix invalid `mkdir` command
- Fix "oci runtime error" when starting Hyperkube container with Docker v1.11 (see https://github.com/kubernetes/kubernetes/issues/25729 and https://github.com/docker/docker/issues/22684)

In case someone has the same issue:
I got another error when running v1.3.3 on RASPBIAN JESSIE LITE. To solve it I added `cgroup_enable=cpuset` to `/boot/cmdline.txt` (see https://github.com/kubernetes/kubernetes/issues/26038#issuecomment-232765600)
